### PR TITLE
VAD-18622 Bump Ivy Version to 2.5.1 to fix critical vulnerability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.swp
 *~
 .DS_Store
+.vscode
 .bsp/
 .cache
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
-    <ivy.version>2.5.0</ivy.version>
+    <ivy.version>2.5.1</ivy.version>
     <oro.version>2.0.8</oro.version>
     <!--
     If you changes codahale.metrics.version, you also need to change


### PR DESCRIPTION
- This PR fixes the CRITICAL vulnerability in `apache.ivy` by updating its version in Spark's `pom.xml` file. 

- This change was validated by creating a custom VAD image and ensuring that the ExMachinaService with this custom driver image enables a user to utilize the Canvas.

- Corresponding c3vad PR for using new custom Spark Image: https://github.com/c3-e/c3vad/pull/8357
